### PR TITLE
Add repository field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,5 +14,9 @@
   },
   "bin": {
     "screenit": "./app.js"
-  }
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Coteh/screenit.git",
+  },
 }


### PR DESCRIPTION
Adds `repository` field to `package.json` so npm can pick it up and add link to repo on sidebar of npm package page.